### PR TITLE
Upload generated hwdb files

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -61,3 +61,19 @@ jobs:
           if-no-files-found: error
           path: |
             pdfs
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: hwdb input files
+          if-no-files-found: error
+          path: |
+            hwdb-inputs
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Final hwdb file
+          if-no-files-found: error
+          path: |
+            90-iocost-tune.hwdb


### PR DESCRIPTION
This needs https://github.com/iocost-benchmark/iocost-benchmarks-ci/pull/8 to be in and 2.2.4 to be released to work.