### PR TITLE
Enable dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+    - package-ecosystem: "github-actions"
+      directory: "/" # Location of package manifests
+      schedule:
+          interval: "weekly"
+      open-pull-requests-limit: 10
+      assignees:
+        - "santoshmahto7"


### PR DESCRIPTION
dependabot automatically checks for dependency and create pull request. We are enabling this feature to automatically update github actions.